### PR TITLE
fix: dockerfile and startup script for orion proxy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,43 +1,64 @@
+# Stage 1: The Builder
 FROM rust:1.84 AS orion-builder
 
-#RUN rustup component add rustfmt
+# install build-time dependencies for the Rust application.
+RUN apt-get update && \
+    apt-get install -y protobuf-compiler && \
+    rm -rf /var/lib/apt/lists/*
 
+# set the working directory inside the container.
 WORKDIR /tmp/orion
 
-RUN <<EOF
-apt update
-apt install -y protobuf-compiler
-EOF
+# copy the dependency manifests first to leverage Docker's layer caching.
+COPY Cargo.toml Cargo.lock ./
 
+# create a dummy main.rs file and workspace members. This is a common pattern
+RUN mkdir -p src && echo 'fn main() {}' > src/main.rs
 
-COPY ./orion-xds ./orion-xds
-COPY ./orion-proxy ./orion-proxy
-COPY ./orion-data-plane-api ./orion-data-plane-api
-COPY ./orion-error ./orion-error
-COPY ./orion-lib ./orion-lib
-COPY ./envoy-data-plane-api ./envoy-data-plane-api
-COPY ./orion-configuration ./orion-configuration
+RUN set -e; \
+    for member in \
+    orion-lib \
+    orion-xds \
+    orion-proxy \
+    orion-error \
+    orion-configuration \
+    orion-data-plane-api \
+    envoy-data-plane-api; \
+    do \
+    mkdir -p "${member}/src"; \
+    printf '[package]\nname = "%s"\nversion = "0.1.0"\nedition = "2021"\n\n[lib]\npath = "src/lib.rs"\n' \
+    "${member}" > "${member}/Cargo.toml"; \
+    touch "${member}/src/lib.rs"; \
+    done
 
+# fetch and download all dependencies defined in Cargo.lock.
+RUN cargo fetch
 
-COPY rustfmt.toml ./
-COPY Cargo.toml ./
-COPY Cargo.lock ./
+# copy the rest of the application source code.
+COPY . .
 
-
+# build the application in release mode for performance.
 RUN cargo build --release
 
-### Split into two files; one to build and one to actually run it
-###https://docs.docker.com/develop/develop-images/multistage-build/
-
+# Stage 2: The Final Runtime Image
 FROM debian:bookworm-slim
-RUN <<EOF
-apt update
-apt upgrade -y
-apt install -y ca-certificates libssl3
-EOF
 
-COPY ./docker/start_proxy.sh ./start_proxy.sh
+# install the root CA certificates package.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
+# copy the runtime configuration file into the final image.
+COPY ./orion-proxy/conf/orion-runtime.yaml /etc/orion/
+
+# copy the startup script and make it executable.
+COPY --chmod=+x ./docker/start_proxy.sh /start_proxy.sh
+
+# copy only the compiled application binary from the builder stage.
 COPY --from=orion-builder /tmp/orion/target/release/orion /orion
+
+# expose the ports the application listens on.
 EXPOSE 8080 8000 50051
+
+# set the command that will be run when the container starts.
 ENTRYPOINT ["/start_proxy.sh"]

--- a/docker/start_proxy.sh
+++ b/docker/start_proxy.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-#./replace_control_plane.sh
-#./orion --config orion-config.yaml
+set -e
 
-echo "$@"
-#echo "Config file "
+if [[ -n "${CONTROL_PLANE_IP}" ]]; then
+  sed -i "s|CONTROL_PLANE_IP|${CONTROL_PLANE_IP}|g" /etc/orion/orion-runtime.yaml
+fi
+
 export RUST_BACKTRACE=1
-#more /orion-config/orion-bootstrap.yaml
-./orion --config /orion-config/orion-bootstrap.yaml
+exec /orion --config /etc/orion/orion-runtime.yaml


### PR DESCRIPTION
This PR introduces a multi-stage `Dockerfile` and a corresponding `start_proxy.sh` entrypoint script to build and run the orion service in a containerized environment.

This provides a standardized, reproducible, and secure way to deploy the application.

@YaoZengzeng let me know if anything more is to be added here!