### PR TITLE
Update copyright headers from Huawei Cloud Computing to kmesh authors

### DIFF
--- a/orion-configuration/src/config.rs
+++ b/orion-configuration/src/config.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/bootstrap.rs
+++ b/orion-configuration/src/config/bootstrap.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/cluster.rs
+++ b/orion-configuration/src/config/cluster.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/cluster/cluster_specifier.rs
+++ b/orion-configuration/src/config/cluster/cluster_specifier.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/cluster/health_check.rs
+++ b/orion-configuration/src/config/cluster/health_check.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/cluster/http_protocol_options.rs
+++ b/orion-configuration/src/config/cluster/http_protocol_options.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/common.rs
+++ b/orion-configuration/src/config/common.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/core.rs
+++ b/orion-configuration/src/config/core.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/listener.rs
+++ b/orion-configuration/src/config/listener.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/listener_filters.rs
+++ b/orion-configuration/src/config/listener_filters.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/log.rs
+++ b/orion-configuration/src/config/log.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/network_filters.rs
+++ b/orion-configuration/src/config/network_filters.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/network_filters/http_connection_manager.rs
+++ b/orion-configuration/src/config/network_filters/http_connection_manager.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/network_filters/http_connection_manager/header_matcher.rs
+++ b/orion-configuration/src/config/network_filters/http_connection_manager/header_matcher.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/network_filters/http_connection_manager/header_modifer.rs
+++ b/orion-configuration/src/config/network_filters/http_connection_manager/header_modifer.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/network_filters/http_connection_manager/http_filters.rs
+++ b/orion-configuration/src/config/network_filters/http_connection_manager/http_filters.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/network_filters/http_connection_manager/http_filters/http_rbac.rs
+++ b/orion-configuration/src/config/network_filters/http_connection_manager/http_filters/http_rbac.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/network_filters/http_connection_manager/http_filters/local_rate_limit.rs
+++ b/orion-configuration/src/config/network_filters/http_connection_manager/http_filters/local_rate_limit.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/network_filters/http_connection_manager/http_filters/router.rs
+++ b/orion-configuration/src/config/network_filters/http_connection_manager/http_filters/router.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/network_filters/http_connection_manager/route.rs
+++ b/orion-configuration/src/config/network_filters/http_connection_manager/route.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/network_filters/network_rbac.rs
+++ b/orion-configuration/src/config/network_filters/network_rbac.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/network_filters/tcp_proxy.rs
+++ b/orion-configuration/src/config/network_filters/tcp_proxy.rs
@@ -1,8 +1,8 @@
 #![allow(deprecated)]
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/runtime.rs
+++ b/orion-configuration/src/config/runtime.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/secret.rs
+++ b/orion-configuration/src/config/secret.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/transport.rs
+++ b/orion-configuration/src/config/transport.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/config/util.rs
+++ b/orion-configuration/src/config/util.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/lib.rs
+++ b/orion-configuration/src/lib.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::wildcard_imports)]
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/main.rs
+++ b/orion-configuration/src/main.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::print_stdout)]
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-configuration/src/options.rs
+++ b/orion-configuration/src/options.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-data-plane-api/src/bootstrap_loader/bootstrap.rs
+++ b/orion-data-plane-api/src/bootstrap_loader/bootstrap.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-data-plane-api/src/bootstrap_loader/mod.rs
+++ b/orion-data-plane-api/src/bootstrap_loader/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-data-plane-api/src/decode.rs
+++ b/orion-data-plane-api/src/decode.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-data-plane-api/src/envoy_validation/mod.rs
+++ b/orion-data-plane-api/src/envoy_validation/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-data-plane-api/src/lib.rs
+++ b/orion-data-plane-api/src/lib.rs
@@ -1,8 +1,8 @@
 #![warn(clippy::unwrap_used)]
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-data-plane-api/src/xds/bindings.rs
+++ b/orion-data-plane-api/src/xds/bindings.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-data-plane-api/src/xds/client.rs
+++ b/orion-data-plane-api/src/xds/client.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-data-plane-api/src/xds/mod.rs
+++ b/orion-data-plane-api/src/xds/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-data-plane-api/src/xds/model.rs
+++ b/orion-data-plane-api/src/xds/model.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-error/src/lib.rs
+++ b/orion-error/src/lib.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/body/mod.rs
+++ b/orion-lib/src/body/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/body/poly_body.rs
+++ b/orion-lib/src/body/poly_body.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/body/timeout_body.rs
+++ b/orion-lib/src/body/timeout_body.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/balancers/default_balancer.rs
+++ b/orion-lib/src/clusters/balancers/default_balancer.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/balancers/hash_policy.rs
+++ b/orion-lib/src/clusters/balancers/hash_policy.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/balancers/healthy.rs
+++ b/orion-lib/src/clusters/balancers/healthy.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/balancers/least.rs
+++ b/orion-lib/src/clusters/balancers/least.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/balancers/maglev.rs
+++ b/orion-lib/src/clusters/balancers/maglev.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/balancers/mod.rs
+++ b/orion-lib/src/clusters/balancers/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/balancers/priority.rs
+++ b/orion-lib/src/clusters/balancers/priority.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/balancers/random.rs
+++ b/orion-lib/src/clusters/balancers/random.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/balancers/ring.rs
+++ b/orion-lib/src/clusters/balancers/ring.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/balancers/wrr.rs
+++ b/orion-lib/src/clusters/balancers/wrr.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/cached_watch.rs
+++ b/orion-lib/src/clusters/cached_watch.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/cluster.rs
+++ b/orion-lib/src/clusters/cluster.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/clusters_manager.rs
+++ b/orion-lib/src/clusters/clusters_manager.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/health/checkers/checker.rs
+++ b/orion-lib/src/clusters/health/checkers/checker.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/health/checkers/grpc/mod.rs
+++ b/orion-lib/src/clusters/health/checkers/grpc/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/health/checkers/grpc/tests.rs
+++ b/orion-lib/src/clusters/health/checkers/grpc/tests.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/health/checkers/http/mod.rs
+++ b/orion-lib/src/clusters/health/checkers/http/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/health/checkers/http/tests.rs
+++ b/orion-lib/src/clusters/health/checkers/http/tests.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/health/checkers/mod.rs
+++ b/orion-lib/src/clusters/health/checkers/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/health/checkers/tcp/mod.rs
+++ b/orion-lib/src/clusters/health/checkers/tcp/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/health/checkers/tcp/tests.rs
+++ b/orion-lib/src/clusters/health/checkers/tcp/tests.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/health/checkers/tests.rs
+++ b/orion-lib/src/clusters/health/checkers/tests.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/health/counter.rs
+++ b/orion-lib/src/clusters/health/counter.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/health/manager.rs
+++ b/orion-lib/src/clusters/health/manager.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/health/mod.rs
+++ b/orion-lib/src/clusters/health/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/load_assignment.rs
+++ b/orion-lib/src/clusters/load_assignment.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/mod.rs
+++ b/orion-lib/src/clusters/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/clusters/retry_policy.rs
+++ b/orion-lib/src/clusters/retry_policy.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/configuration/mod.rs
+++ b/orion-lib/src/configuration/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/lib.rs
+++ b/orion-lib/src/lib.rs
@@ -1,8 +1,8 @@
 #![recursion_limit = "128"]
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/listeners/filterchain.rs
+++ b/orion-lib/src/listeners/filterchain.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/listeners/http_connection_manager.rs
+++ b/orion-lib/src/listeners/http_connection_manager.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/listeners/http_connection_manager/direct_response.rs
+++ b/orion-lib/src/listeners/http_connection_manager/direct_response.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/listeners/http_connection_manager/redirect.rs
+++ b/orion-lib/src/listeners/http_connection_manager/redirect.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/listeners/http_connection_manager/route.rs
+++ b/orion-lib/src/listeners/http_connection_manager/route.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/listeners/listener.rs
+++ b/orion-lib/src/listeners/listener.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/listeners/listeners_manager.rs
+++ b/orion-lib/src/listeners/listeners_manager.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/listeners/mod.rs
+++ b/orion-lib/src/listeners/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/listeners/rate_limiter/mod.rs
+++ b/orion-lib/src/listeners/rate_limiter/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/listeners/rate_limiter/token_bucket.rs
+++ b/orion-lib/src/listeners/rate_limiter/token_bucket.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/listeners/synthetic_http_response.rs
+++ b/orion-lib/src/listeners/synthetic_http_response.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/listeners/tcp_proxy.rs
+++ b/orion-lib/src/listeners/tcp_proxy.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/observability/mod.rs
+++ b/orion-lib/src/observability/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/observability/opentelemetry.rs
+++ b/orion-lib/src/observability/opentelemetry.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/observability/opentelemetry/metric_exporters.rs
+++ b/orion-lib/src/observability/opentelemetry/metric_exporters.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/observability/opentelemetry/metric_exporters/otel.rs
+++ b/orion-lib/src/observability/opentelemetry/metric_exporters/otel.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/observability/opentelemetry/metric_exporters/prometheus.rs
+++ b/orion-lib/src/observability/opentelemetry/metric_exporters/prometheus.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/observability/opentelemetry/metric_exporters/stdout.rs
+++ b/orion-lib/src/observability/opentelemetry/metric_exporters/stdout.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/observability/prometheus_server.rs
+++ b/orion-lib/src/observability/prometheus_server.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/secrets/mod.rs
+++ b/orion-lib/src/secrets/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/secrets/secrets_manager.rs
+++ b/orion-lib/src/secrets/secrets_manager.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/secrets/tls_configurator/configurator.rs
+++ b/orion-lib/src/secrets/tls_configurator/configurator.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/secrets/tls_configurator/mod.rs
+++ b/orion-lib/src/secrets/tls_configurator/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/secrets/tls_configurator/tls_configurator_builder.rs
+++ b/orion-lib/src/secrets/tls_configurator/tls_configurator_builder.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/thread_local.rs
+++ b/orion-lib/src/thread_local.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/transport/bind_device.rs
+++ b/orion-lib/src/transport/bind_device.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/transport/connector.rs
+++ b/orion-lib/src/transport/connector.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/transport/grpc_channel.rs
+++ b/orion-lib/src/transport/grpc_channel.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/transport/http_channel.rs
+++ b/orion-lib/src/transport/http_channel.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/transport/mod.rs
+++ b/orion-lib/src/transport/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/transport/request_context.rs
+++ b/orion-lib/src/transport/request_context.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/transport/resolver.rs
+++ b/orion-lib/src/transport/resolver.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/transport/tcp_channel.rs
+++ b/orion-lib/src/transport/tcp_channel.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/transport/tls_inspector.rs
+++ b/orion-lib/src/transport/tls_inspector.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-lib/src/utils.rs
+++ b/orion-lib/src/utils.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-proxy/src/core_affinity.rs
+++ b/orion-proxy/src/core_affinity.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-proxy/src/lib.rs
+++ b/orion-proxy/src/lib.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-proxy/src/main.rs
+++ b/orion-proxy/src/main.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-proxy/src/proxy.rs
+++ b/orion-proxy/src/proxy.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-proxy/src/runtime.rs
+++ b/orion-proxy/src/runtime.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-proxy/src/xds_configurator.rs
+++ b/orion-proxy/src/xds_configurator.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-xds/src/lib.rs
+++ b/orion-xds/src/lib.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-xds/src/xds/bindings.rs
+++ b/orion-xds/src/xds/bindings.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-xds/src/xds/client.rs
+++ b/orion-xds/src/xds/client.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-xds/src/xds/mod.rs
+++ b/orion-xds/src/xds/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-xds/src/xds/model.rs
+++ b/orion-xds/src/xds/model.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-xds/src/xds/resources/converters.rs
+++ b/orion-xds/src/xds/resources/converters.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-xds/src/xds/resources/mod.rs
+++ b/orion-xds/src/xds/resources/mod.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/orion-xds/src/xds/server.rs
+++ b/orion-xds/src/xds/server.rs
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: © 2025 Huawei Cloud Computing Technologies Co., Ltd
+// SPDX-FileCopyrightText: © 2025 kmesh authors
 // SPDX-License-Identifier: Apache-2.0
 //
-// Copyright 2025 Huawei Cloud Computing Technologies Co., Ltd
+// Copyright 2025 kmesh authors
 //
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- Updated SPDX-FileCopyrightText from Huawei Cloud Computing Technologies Co., Ltd to kmesh authors
- Updated Copyright line from Huawei Cloud Computing Technologies Co., Ltd to kmesh authors
- Applied changes across 121 Rust source files
- Maintains Apache 2.0 license and all other header content

fixes #19 