### PR TITLE
chore: add minimal dependabot config for auto dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      async-ecosystem:
+        patterns:
+          - "tokio*"
+          - "hyper*"
+          - "tower*"
+          - "futures*"
+      protobuf-ecosystem:
+        patterns:
+          - "prost*"
+          - "tonic*"
+      serialization:
+        patterns:
+          - "serde*"
+      tracing-ecosystem:
+        patterns:
+          - "tracing*"
+      rustls-ecosystem:
+        patterns:
+          - "rustls*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
This PR adds a minimal `.github/dependabot.yml` configuration to enable automatic dependency updates for:
- Rust (Cargo) dependencies
- GitHub Actions workflows

- Groups related dependencies to reduce PR noise
- Runs weekly and limits open PRs for easier review

This will help keep dependencies up-to-date and improve project security and maintainability.

fixes #35