### PR TITLE
Replace compact_str with smol_str throughout the codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 dependencies = [
  "serde",
 ]
@@ -547,20 +547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -647,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -657,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -669,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -708,21 +700,6 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "compact_str"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "serde",
- "static_assertions",
 ]
 
 [[package]]
@@ -873,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
 ]
@@ -1004,6 +981,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
 
 [[package]]
 name = "fixedbitset"
@@ -1798,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru-cache"
@@ -2114,7 +2097,6 @@ dependencies = [
  "bounded-integer",
  "bytes",
  "clap",
- "compact_str",
  "exponential-backoff",
  "http",
  "http-serde-ext",
@@ -2133,6 +2115,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_regex",
  "serde_yaml",
+ "smol_str",
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
@@ -2171,7 +2154,6 @@ dependencies = [
  "ahash",
  "bitflags",
  "chrono",
- "compact_str",
  "criterion",
  "dhat",
  "http",
@@ -2200,10 +2182,10 @@ dependencies = [
 name = "orion-interner"
 version = "0.1.0"
 dependencies = [
- "compact_str",
  "http",
  "lasso",
  "serde",
+ "smol_str",
 ]
 
 [[package]]
@@ -2218,7 +2200,6 @@ dependencies = [
  "atomic-time",
  "bounded-integer",
  "bytes",
- "compact_str",
  "enum_dispatch",
  "exponential-backoff",
  "futures",
@@ -2310,7 +2291,6 @@ dependencies = [
  "axum 0.8.4",
  "axum-test",
  "caps",
- "compact_str",
  "dhat",
  "futures",
  "http",
@@ -2329,6 +2309,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "smol_str",
  "thiserror 1.0.69",
  "tikv-jemallocator",
  "tokio",
@@ -2346,7 +2327,6 @@ dependencies = [
  "arc-swap",
  "arrayvec",
  "bounded-integer",
- "compact_str",
  "http",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -2517,9 +2497,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -3504,12 +3484,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -3519,15 +3498,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3944,9 +3923,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ orion-xds            = { path = "orion-xds" }
 abort-on-drop       = "0.2"
 bounded-integer     = "0.5.8"
 bytes               = "1"
-compact_str         = { version = "0.8.0", features = ["serde"] }
+smol_str            = { version = "0.3.2", features = ["serde"] }
 exponential-backoff = "1.2.0"
 futures             = "0.3"
 http                = "1.0"

--- a/orion-configuration/Cargo.toml
+++ b/orion-configuration/Cargo.toml
@@ -13,8 +13,8 @@ base64 = "0.22.1"
 base64-serde = "0.7.0"
 bounded-integer = { version = "0.5.8", features = ["serde", "types"] }
 bytes.workspace = true
+smol_str.workspace = true
 clap = { version = "4.5.46", features = ["derive"] }
-compact_str.workspace = true
 exponential-backoff.workspace = true
 http.workspace = true
 http-serde-ext = "1.0.2"

--- a/orion-configuration/src/config/bootstrap.rs
+++ b/orion-configuration/src/config/bootstrap.rs
@@ -20,8 +20,8 @@ use std::time::Duration;
 use crate::config::{
     cluster::Cluster, common::is_default, core::Address, listener::Listener, metrics::StatsSink, secret::Secret,
 };
-use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct Bootstrap {
@@ -40,15 +40,15 @@ pub struct Bootstrap {
 }
 
 impl Bootstrap {
-    pub fn get_ads_configs(&self) -> &[CompactString] {
+    pub fn get_ads_configs(&self) -> &[SmolStr] {
         self.dynamic_resources.as_ref().map(|dr| dr.grpc_cluster_specifiers.as_slice()).unwrap_or_default()
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct Node {
-    pub id: CompactString,
-    pub cluster_id: CompactString,
+    pub id: SmolStr,
+    pub cluster_id: SmolStr,
 }
 
 impl Node {
@@ -65,7 +65,7 @@ impl Node {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DynamicResources {
-    pub grpc_cluster_specifiers: Vec<CompactString>,
+    pub grpc_cluster_specifiers: Vec<SmolStr>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -88,7 +88,6 @@ mod envoy_conversions {
     #![allow(deprecated)]
     use super::{Admin, Bootstrap, DynamicResources, Node, StaticResources};
     use crate::config::{common::*, grpc::Duration, metrics::StatsSink};
-    use compact_str::CompactString;
     use orion_data_plane_api::envoy_data_plane_api::envoy::config::{
         bootstrap::v3::{
             bootstrap::{DynamicResources as EnvoyDynamicResources, StaticResources as EnvoyStaticResources},
@@ -101,6 +100,7 @@ mod envoy_conversions {
         },
         metrics::v3::stats_sink::ConfigType,
     };
+    use smol_str::SmolStr;
 
     impl Bootstrap {
         pub fn deserialize_from_envoy<R: std::io::Read>(rdr: R) -> Result<Self, GenericError> {
@@ -310,7 +310,7 @@ mod envoy_conversions {
                                 )
                                 .with_node("target_specifier")?;
                                 let cluster_name = required!(cluster_name).with_node("target_specifier")?;
-                                cluster_specifiers.push(CompactString::from(cluster_name))
+                                cluster_specifiers.push(SmolStr::from(cluster_name))
                             },
                             EnvoyGrpcTargetSpecifier::GoogleGrpc(_) => {
                                 return Err(GenericError::unsupported_variant("GoogleGrpc"))

--- a/orion-configuration/src/config/cluster/health_check.rs
+++ b/orion-configuration/src/config/cluster/health_check.rs
@@ -16,12 +16,12 @@
 //
 
 use crate::config::common::is_default;
-use compact_str::CompactString;
 use http::{
     uri::{Authority, PathAndQuery},
     Method,
 };
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
+use smol_str::SmolStr;
 use std::{ops::Range, str::FromStr, time::Duration};
 
 pub use super::http_protocol_options::Codec;
@@ -254,7 +254,7 @@ pub struct TcpHealthCheck {
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct GrpcHealthCheck {
-    pub service_name: CompactString,
+    pub service_name: SmolStr,
 }
 
 #[cfg(feature = "envoy-conversions")]

--- a/orion-configuration/src/config/common.rs
+++ b/orion-configuration/src/config/common.rs
@@ -15,9 +15,9 @@
 //
 //
 
-use compact_str::CompactString;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
 use std::{
     borrow::Cow,
     error::Error,
@@ -220,8 +220,8 @@ impl<T> WithNodeOnResult for Result<T, GenericError> {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MetadataKey {
-    pub key: CompactString,
-    pub path: Vec<CompactString>,
+    pub key: SmolStr,
+    pub path: Vec<SmolStr>,
 }
 
 #[cfg(feature = "envoy-conversions")]

--- a/orion-configuration/src/config/core.rs
+++ b/orion-configuration/src/config/core.rs
@@ -18,9 +18,9 @@
 use crate::config::common::*;
 use base64::engine::general_purpose::STANDARD;
 use base64_serde::base64_serde_type;
-use compact_str::CompactString;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
 use std::{
     fmt::Debug,
     hash::{Hash, Hasher},
@@ -31,18 +31,18 @@ base64_serde_type!(Base64Standard, STANDARD);
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DataSource {
-    Path(CompactString),
+    Path(SmolStr),
     InlineBytes(#[serde(with = "Base64Standard")] Vec<u8>),
-    InlineString(CompactString),
-    EnvironmentVariable(CompactString),
+    InlineString(SmolStr),
+    EnvironmentVariable(SmolStr),
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum DataSourceReadError {
     #[error("failed to read file \"{0}\"")]
-    IoError(CompactString, #[source] std::io::Error),
+    IoError(SmolStr, #[source] std::io::Error),
     #[error("failed to read environment variable \"{0}\"")]
-    EnvError(CompactString, #[source] std::env::VarError),
+    EnvError(SmolStr, #[source] std::env::VarError),
 }
 
 impl DataSource {
@@ -199,10 +199,10 @@ impl StringMatcher {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StringMatcherPattern {
-    Exact(CompactString),
-    Prefix(CompactString),
-    Suffix(CompactString),
-    Contains(CompactString),
+    Exact(SmolStr),
+    Prefix(SmolStr),
+    Suffix(SmolStr),
+    Contains(SmolStr),
     Regex(#[serde(with = "serde_regex")] Regex),
 }
 

--- a/orion-configuration/src/config/network_filters/tracing.rs
+++ b/orion-configuration/src/config/network_filters/tracing.rs
@@ -16,8 +16,8 @@
 //
 
 use ::bounded_integer::BoundedU16;
-use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
 
 use orion_data_plane_api::envoy_data_plane_api::envoy::{
     extensions::filters::network::http_connection_manager::v3::http_connection_manager::Tracing as EnvoyTracing,
@@ -39,7 +39,7 @@ pub enum SupportedTracingProvider {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct OpenTelemetryConfig {
     pub grpc_service: Option<GrpcService>,
-    pub service_name: CompactString,
+    pub service_name: SmolStr,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -69,8 +69,8 @@ pub struct TracingKey(pub ListenerName, pub FilterChainMatchHash);
 #[cfg(feature = "envoy-conversions")]
 mod envoy_conversions {
     use crate::config::{common::envoy_conversions::IsUsed, unsupported_field, GenericError};
-    use compact_str::ToCompactString;
     use orion_data_plane_api::envoy_data_plane_api::prost::Message;
+    use smol_str::ToSmolStr;
 
     use super::*;
 
@@ -158,7 +158,7 @@ mod envoy_conversions {
 
             Ok(SupportedTracingProvider::OpenTelemetry(OpenTelemetryConfig {
                 grpc_service,
-                service_name: service_name.to_compact_string(),
+                service_name: service_name.to_smolstr(),
             }))
         }
     }

--- a/orion-configuration/src/config/runtime.rs
+++ b/orion-configuration/src/config/runtime.rs
@@ -22,7 +22,6 @@ use std::{
     num::{NonZeroU32, NonZeroUsize},
     ops::Deref,
 };
-use tracing;
 
 use crate::options::Options;
 
@@ -144,7 +143,7 @@ fn get_cgroup_v2_cpu_limit() -> crate::Result<usize> {
 }
 
 fn parse_cgroup_v2_cpu_max(content: &str) -> crate::Result<usize> {
-    let parts: Vec<&str> = content.trim().split_whitespace().collect();
+    let parts: Vec<&str> = content.split_whitespace().collect();
     if parts.len() == 2 && parts[0] != "max" {
         let quota: i64 = parts[0].parse()?;
         let period: i64 = parts[1].parse()?;
@@ -160,7 +159,7 @@ fn parse_cgroup_v2_cpu_max(content: &str) -> crate::Result<usize> {
 
 fn get_cgroup_v1_cpu_limit() -> crate::Result<usize> {
     let cgroup_path = get_cgroup_v1_cpu_path()?;
-    let quota_path = format!("{}/cpu.cfs_quota_us", cgroup_path);
+    let quota_path = format!("{cgroup_path}/cpu.cfs_quota_us");
     let period_path = format!("{}/cpu.cfs_period_us", cgroup_path);
 
     let quota_content = std::fs::read_to_string(&quota_path)?;

--- a/orion-configuration/src/config/secret.rs
+++ b/orion-configuration/src/config/secret.rs
@@ -16,13 +16,13 @@
 //
 
 use crate::config::core::DataSource;
-use compact_str::CompactString;
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Secret {
-    pub name: CompactString,
+    pub name: SmolStr,
     #[serde(flatten)]
     pub kind: Type,
 }
@@ -100,19 +100,19 @@ mod envoy_conversions {
     #![allow(deprecated)]
     use super::{Secret, TlsCertificate, Type, ValidationContext};
     use crate::config::common::*;
-    use compact_str::CompactString;
     use orion_data_plane_api::envoy_data_plane_api::envoy::extensions::transport_sockets::tls::v3::{
         secret::Type as EnvoyType, CertificateValidationContext as EnvoyCertificateValidationContext,
         Secret as EnvoySecret, TlsCertificate as EnvoyTlsCertificate,
     };
+    use smol_str::SmolStr;
 
     impl TryFrom<EnvoySecret> for Secret {
         type Error = GenericError;
         fn try_from(envoy: EnvoySecret) -> Result<Self, Self::Error> {
             let EnvoySecret { name, r#type } = envoy;
-            let name: CompactString = required!(name)?.into();
+            let name = required!(name)?;
             let kind = convert_opt!(r#type, "type").with_name(name.clone())?;
-            Ok(Self { name, kind })
+            Ok(Self { name: SmolStr::from(name), kind })
         }
     }
     impl TryFrom<EnvoyType> for Type {

--- a/orion-format/Cargo.toml
+++ b/orion-format/Cargo.toml
@@ -12,12 +12,12 @@ workspace = true
 http.workspace              = true
 orion-http-header.workspace = true
 orion-interner.workspace = true
-thiserror.workspace      = true
+thiserror.workspace = true
+smol_str.workspace = true
 
 ahash          = "0.8.11"
 bitflags        = { version = "2.9.0", features = ["serde"] }
 chrono         = "0.4.40"
-compact_str    = "0.8.0"
 criterion      = "0.5.1"
 dhat           = "0.3.3"
 http-serde-ext = "1.0.2"
@@ -25,7 +25,6 @@ hyper          = { version = "1" }
 itoa           = "1.0.15"
 ptrie          = "0.7.2"
 serde          = { workspace = true, features = ["rc"] }
-smol_str       = { version = "0.3.2", features = ["serde"] }
 thread_local   = "1.1.8"
 traceparent    = "0.0.3"
 uuid           = { version = "1.16.0", features = ["v4"] }

--- a/orion-format/src/context.rs
+++ b/orion-format/src/context.rs
@@ -30,7 +30,8 @@ use chrono::{DateTime, Datelike, Timelike, Utc};
 use http::{uri::Authority, Request, Response};
 use orion_http_header::{X_ENVOY_ORIGINAL_PATH, X_REQUEST_ID};
 use orion_interner::StringInterner;
-use smol_str::{format_smolstr, SmolStr, SmolStrBuilder, ToSmolStr};
+use smol_str::ToSmolStr;
+use smol_str::{format_smolstr, SmolStr, SmolStrBuilder};
 use uuid::Uuid;
 
 pub trait Context {
@@ -473,10 +474,10 @@ pub fn format_system_time_heapless(time: SystemTime) -> heapless::String<24> {
 }
 
 #[cfg(any())]
-pub fn format_system_time_compact(time: SystemTime) -> CompactString {
+pub fn format_system_time_compact(time: SystemTime) -> SmolStr {
     let datetime: DateTime<Utc> = time.into();
     let mut buffer = itoa::Buffer::new();
-    let mut rfc3999 = CompactString::default();
+    let mut rfc3999 = SmolStr::default();
 
     _ = rfc3999.push_str(buffer.format(datetime.year()));
     _ = rfc3999.push('-');

--- a/orion-interner/Cargo.toml
+++ b/orion-interner/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace      = true
 workspace = true
 
 [dependencies]
-compact_str.workspace = true
+smol_str.workspace = true
 http.workspace = true
 lasso = { version = "0.7.3", features = [
   "ahash",

--- a/orion-interner/src/lib.rs
+++ b/orion-interner/src/lib.rs
@@ -17,9 +17,9 @@
 
 use std::sync::OnceLock;
 
-use compact_str::CompactString;
 use http::Version;
 use lasso::ThreadedRodeo;
+use smol_str::SmolStr;
 
 static GLOBAL_INTERNER: OnceLock<ThreadedRodeo> = OnceLock::new();
 
@@ -52,7 +52,7 @@ impl StringInterner for String {
     }
 }
 
-impl StringInterner for CompactString {
+impl StringInterner for SmolStr {
     fn to_static_str(&self) -> &'static str {
         intern_str(self)
     }

--- a/orion-lib/Cargo.toml
+++ b/orion-lib/Cargo.toml
@@ -13,7 +13,7 @@ arrayvec = "0.7.6"
 async-stream = "0.3"
 atomic-time = "0.1.4"
 bytes.workspace = true
-compact_str.workspace = true
+smol_str.workspace = true
 enum_dispatch = "0.3.13"
 exponential-backoff.workspace = true
 futures.workspace = true
@@ -54,7 +54,6 @@ rustls-platform-verifier = { version = "0.3" }
 rustls-webpki = "0.102"
 scopeguard = "1.2.0"
 serde.workspace = true
-smol_str = "0.3.2"
 thiserror.workspace = true
 thread-id = "5.0.0"
 thread_local = "1.1.8"

--- a/orion-lib/src/access_log.rs
+++ b/orion-lib/src/access_log.rs
@@ -22,13 +22,13 @@ mod log_writer;
 pub mod logger;
 mod pool;
 
-use compact_str::CompactString;
 use logger::AccessLogger;
 use once_cell::sync::OnceCell;
 use orion_configuration::config::network_filters::access_log::AccessLogConf;
 use orion_format::FormattedMessage;
 use parking_lot::Mutex;
 use pool::LoggerPool;
+use smol_str::SmolStr;
 use tracing_appender::rolling::Rotation;
 
 use std::{fmt::Display, hash::Hash, sync::Arc};
@@ -44,7 +44,7 @@ use tracing::{error, info};
 /// - `Admin`: Refers to the Envoy admin interface.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Target {
-    Listener(CompactString),
+    Listener(SmolStr),
     Admin,
 }
 

--- a/orion-lib/src/listeners/filterchain.rs
+++ b/orion-lib/src/listeners/filterchain.rs
@@ -25,7 +25,6 @@ use crate::{
     transport::AsyncReadWrite,
     AsyncStream, ConversionContext, Error, Result,
 };
-use compact_str::CompactString;
 use futures::TryFutureExt;
 use hyper::{service::Service, Request};
 use hyper_util::rt::{TokioExecutor, TokioIo};
@@ -44,6 +43,7 @@ use orion_metrics::{
 };
 use rustls::{server::Acceptor, ServerConfig};
 use scopeguard::defer;
+use smol_str::SmolStr;
 use std::{sync::Arc, thread::ThreadId};
 use tracing::{debug, warn};
 
@@ -61,7 +61,7 @@ pub enum ConnectionHandler {
 
 #[derive(Debug, Clone)]
 pub struct Filterchain {
-    pub name: CompactString,
+    pub name: SmolStr,
     pub rbac_filters: Vec<NetworkRbac>,
     pub tls_configurator: Option<TlsConfigurator<ServerConfig, WantsToBuildServer>>,
 }
@@ -87,7 +87,7 @@ impl TryFrom<ConversionContext<'_, MainFilter>> for MainFilterBuilder {
 
 #[derive(Debug, Clone)]
 pub struct FilterchainBuilder {
-    name: CompactString,
+    name: SmolStr,
     listener_name: Option<&'static str>,
     filter_chain_match_hash: u64,
     main_filter: MainFilterBuilder,

--- a/orion-lib/src/listeners/http_connection_manager.rs
+++ b/orion-lib/src/listeners/http_connection_manager.rs
@@ -31,7 +31,6 @@ mod upgrades;
 
 use ::http::HeaderValue;
 use arc_swap::ArcSwap;
-use compact_str::{CompactString, ToCompactString};
 use core::time::Duration;
 use futures::future::BoxFuture;
 use hyper::{body::Incoming, service::Service, Request, Response};
@@ -41,6 +40,7 @@ use opentelemetry::KeyValue;
 use orion_configuration::config::GenericError;
 use orion_tracing::span_state::SpanState;
 use orion_tracing::{attributes::HTTP_RESPONSE_STATUS_CODE, with_client_span, with_server_span};
+use smol_str::{SmolStr, ToSmolStr};
 
 use orion_configuration::config::network_filters::http_connection_manager::http_filters::{
     FilterConfigOverride, FilterOverride,
@@ -156,7 +156,7 @@ impl HttpConnectionManagerBuilder {
 pub struct PartialHttpConnectionManager {
     router: Option<RouteConfiguration>,
     codec_type: CodecType,
-    dynamic_route_name: Option<CompactString>,
+    dynamic_route_name: Option<SmolStr>,
     http_filters_hcm: Vec<Arc<HttpFilter>>,
     http_filters_per_route: HashMap<RouteMatch, Vec<Arc<HttpFilter>>>,
     enabled_upgrades: Vec<UpgradeType>,
@@ -171,7 +171,7 @@ pub struct PartialHttpConnectionManager {
 
 #[derive(Debug, Clone)]
 pub struct HttpFilter {
-    pub name: CompactString,
+    pub name: SmolStr,
     pub disabled: bool,
     pub filter: Option<HttpFilterValue>,
 }
@@ -267,7 +267,7 @@ impl TryFrom<ConversionContext<'_, HttpConnectionManagerConfig>> for PartialHttp
                 route_config_name,
                 config_source: ConfigSource { config_source_specifier },
             }) => match config_source_specifier {
-                ConfigSourceSpecifier::ADS => (Some(route_config_name.to_compact_string()), None),
+                ConfigSourceSpecifier::ADS => (Some(route_config_name.to_smolstr()), None),
             },
             RouteSpecifier::RouteConfig(config) => {
                 http_filters_per_route = per_route_http_filters(&config, &http_filters_hcm);
@@ -324,7 +324,7 @@ pub struct HttpConnectionManager {
     pub filter_chain_match_hash: u64,
     router_sender: watch::Sender<Option<Arc<RouteConfiguration>>>,
     pub codec_type: CodecType,
-    dynamic_route_name: Option<CompactString>,
+    dynamic_route_name: Option<SmolStr>,
     http_filters_hcm: Vec<Arc<HttpFilter>>,
     http_filters_per_route: ArcSwap<HashMap<RouteMatch, Vec<Arc<HttpFilter>>>>,
     enabled_upgrades: Vec<UpgradeType>,
@@ -348,7 +348,7 @@ impl HttpConnectionManager {
     }
 
     #[inline]
-    pub fn get_route_id(&self) -> Option<&CompactString> {
+    pub fn get_route_id(&self) -> Option<&SmolStr> {
         self.dynamic_route_name.as_ref()
     }
 
@@ -1049,7 +1049,7 @@ fn eval_http_finish_context(
 
     let loggers: Vec<LogFormatterLocal> = std::mem::take(access_loggers);
     let messages = loggers.into_iter().map(LogFormatterLocal::into_message).collect::<Vec<_>>();
-    log_access(permit, Target::Listener(listener_name.to_compact_string()), messages);
+    log_access(permit, Target::Listener(listener_name.to_smolstr()), messages);
 }
 
 fn apply_authorization_rules<B>(rbac: &HttpRbac, req: &Request<B>) -> FilterDecision {

--- a/orion-lib/src/listeners/listener.rs
+++ b/orion-lib/src/listeners/listener.rs
@@ -498,7 +498,7 @@ impl Listener {
                     if let ConnectionHandler::Http(http_manager) = &chain.handler {
                         let route_id = http_manager.get_route_id();
                         if let Some(route_id) = route_id {
-                            if route_id == id {
+                            if route_id == &id {
                                 debug!("{listener_name} Route updated {id} {route:?}");
                                 http_manager.update_route(route.clone());
                             }
@@ -512,7 +512,7 @@ impl Listener {
                 for chain in filter_chains.values() {
                     if let ConnectionHandler::Http(http_manager) = &chain.handler {
                         if let Some(route_id) = http_manager.get_route_id() {
-                            if route_id == id {
+                            if route_id == &id {
                                 http_manager.remove_route();
                             }
                         }

--- a/orion-lib/src/listeners/tcp_proxy.rs
+++ b/orion-lib/src/listeners/tcp_proxy.rs
@@ -22,7 +22,6 @@ use crate::{
     transport::connector::TcpErrorContext,
     AsyncStream, Result,
 };
-use compact_str::ToCompactString;
 use orion_configuration::config::{
     cluster::ClusterSpecifier as ClusterSpecifierConfig,
     network_filters::{access_log::AccessLog, tcp_proxy::TcpProxy as TcpProxyConfig},
@@ -32,6 +31,7 @@ use orion_format::{
     types::ResponseFlags,
     LogFormatterLocal,
 };
+use smol_str::ToSmolStr;
 use std::{fmt, net::SocketAddr, sync::Arc, time::Instant};
 use tracing::{debug, error};
 
@@ -175,7 +175,7 @@ impl TcpProxy {
         });
         let permit = log_access_reserve_balanced().await;
         let messages = access_loggers.into_iter().map(LogFormatterLocal::into_message).collect::<Vec<_>>();
-        log_access(permit, Target::Listener(self.listener_name.to_compact_string()), messages);
+        log_access(permit, Target::Listener(self.listener_name.to_smolstr()), messages);
         res
     }
 }

--- a/orion-lib/src/secrets/secrets_manager.rs
+++ b/orion-lib/src/secrets/secrets_manager.rs
@@ -16,7 +16,6 @@
 //
 
 use crate::Result;
-use compact_str::{CompactString, ToCompactString};
 use orion_configuration::{
     config::secret::{Secret, TlsCertificate, Type, ValidationContext},
     VerifySingleIter,
@@ -27,6 +26,7 @@ use rustls::{
     RootCertStore,
 };
 use rustls_pemfile::{certs, pkcs8_private_keys};
+use smol_str::{SmolStr, ToSmolStr};
 use std::sync::Arc;
 use tracing::{debug, warn};
 use webpki::types::ServerName;
@@ -76,7 +76,7 @@ pub struct SecretManager {
 
 #[derive(Debug, Clone)]
 pub struct CertificateSecret {
-    pub name: Option<CompactString>,
+    pub name: Option<SmolStr>,
     pub key: Arc<PrivateKeyDer<'static>>,
     pub certs: Arc<Vec<CertificateDer<'static>>>,
     pub config: TlsCertificate,
@@ -120,7 +120,7 @@ impl TryFrom<&TlsCertificate> for CertificateSecret {
                 let is_server_name = ServerName::try_from(name.clone()).is_ok();
                 debug!("Certificate SAN name {san_name} {name } is server name {is_server_name}");
                 if is_server_name {
-                    server_name = Some(name.to_compact_string());
+                    server_name = Some(name.to_smolstr());
                 }
             }
         }

--- a/orion-lib/src/secrets/tls_configurator/tls_configurator_builder.rs
+++ b/orion-lib/src/secrets/tls_configurator/tls_configurator_builder.rs
@@ -17,11 +17,11 @@
 
 use std::sync::Arc;
 
-use compact_str::CompactString;
 use rustls::{
     client::WebPkiServerVerifier, server::WebPkiClientVerifier, sign::CertifiedKey, ClientConfig, RootCertStore,
     ServerConfig, SupportedProtocolVersion,
 };
+use smol_str::SmolStr;
 use tracing::{debug, warn};
 
 use super::configurator::{get_crypto_key_provider, ClientCert, RelaxedResolvesServerCertUsingSni, ServerCert};
@@ -47,7 +47,7 @@ pub struct WantsClientCert {
 
 #[derive(Debug, Clone)]
 pub struct SecretHolder {
-    pub name: CompactString,
+    pub name: SmolStr,
     pub server_cert: ServerCert,
 }
 
@@ -71,7 +71,7 @@ impl Ord for SecretHolder {
     }
 }
 impl SecretHolder {
-    pub fn new(name: CompactString, server_cert: ServerCert) -> Self {
+    pub fn new(name: SmolStr, server_cert: ServerCert) -> Self {
         Self { name, server_cert }
     }
 }

--- a/orion-lib/src/transport/http_channel.rs
+++ b/orion-lib/src/transport/http_channel.rs
@@ -67,7 +67,7 @@ use webpki::types::ServerName;
 
 #[cfg(feature = "metrics")]
 use {
-    hyper_util::client::legacy::pool::{ConnectionEvent, EventHandler, Tag},
+    hyper_util::client::legacy::pool::{ConnectionEvent, Tag},
     hyper_util::client::legacy::PoolKey,
     std::any::Any,
 };

--- a/orion-proxy/Cargo.toml
+++ b/orion-proxy/Cargo.toml
@@ -36,7 +36,7 @@ tower.workspace                = true
 tracing.workspace              = true
 
 axum = "0.8.1"
-compact_str.workspace = true
+smol_str.workspace = true
 http.workspace = true
 opentelemetry = "0.29.0"
 prometheus = { version = "0.14.0", features = ["process"] }

--- a/orion-proxy/src/admin/config_dump.rs
+++ b/orion-proxy/src/admin/config_dump.rs
@@ -104,7 +104,6 @@ pub async fn get_config_dump(State(admin_state): State<AdminState>) -> Json<Valu
 mod config_dump_tests {
     use super::{super::*, *};
     use axum_test::TestServer;
-    use compact_str::CompactString;
     use orion_configuration::config::{
         core::DataSource,
         network_filters::http_connection_manager::header_modifer::HeaderModifier,
@@ -114,6 +113,7 @@ mod config_dump_tests {
     use orion_lib::{ConfigDump, ListenerConfigurationChange};
     use parking_lot::RwLock;
     use serde_json::json;
+    use smol_str::SmolStr;
     use std::{sync::Arc, time::Instant};
     use tokio::sync::mpsc;
 
@@ -142,7 +142,7 @@ mod config_dump_tests {
     #[test]
     fn test_redact_secrets_tls_certificate() {
         let secret = Secret {
-            name: CompactString::from("test_tls"),
+            name: SmolStr::new_static("test_tls"),
             kind: Type::TlsCertificate(
                 TlsCertificate::try_from(EnvoyTlsCertificate {
                     certificate_chain: Some(EnvoyDataSource {
@@ -171,7 +171,7 @@ mod config_dump_tests {
     #[test]
     fn test_redact_secrets_validation_context() {
         let secret = Secret {
-            name: CompactString::from("test_validation"),
+            name: SmolStr::new_static("test_validation"),
             kind: Type::ValidationContext(
                 ValidationContext::try_from(EnvoyCertificateValidationContext {
                     trusted_ca: Some(EnvoyDataSource {
@@ -231,7 +231,6 @@ mod config_dump_tests {
 
     #[tokio::test]
     async fn config_dump_listeners_and_routes() {
-        use compact_str::CompactString;
         use orion_configuration::config::{
             listener::{FilterChain, FilterChainMatch, Listener, MainFilter},
             network_filters::http_connection_manager::{
@@ -239,20 +238,21 @@ mod config_dump_tests {
                 CodecType, HttpConnectionManager, Route, RouteConfiguration, RouteSpecifier, VirtualHost, XffSettings,
             },
         };
+        use smol_str::SmolStr;
         use std::{
             collections::HashMap,
             net::{IpAddr, Ipv4Addr, SocketAddr},
             time::Duration,
         };
         let listener = Listener {
-            name: CompactString::from("listener1"),
+            name: SmolStr::new_static("listener1"),
             address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080),
             filter_chains: {
                 let mut map = HashMap::new();
                 map.insert(
                     FilterChainMatch::default(),
                     FilterChain {
-                        name: CompactString::from("fc1"),
+                        name: SmolStr::new_static("fc1"),
                         filter_chain_match_hash: 0,
                         tls_config: None,
                         rbac: vec![],
@@ -262,13 +262,13 @@ mod config_dump_tests {
                             http_filters: vec![],
                             enabled_upgrades: vec![],
                             route_specifier: RouteSpecifier::RouteConfig(RouteConfiguration {
-                                name: CompactString::from("route_config1"),
+                                name: SmolStr::new_static("route_config1"),
                                 most_specific_header_mutations_wins: false,
                                 response_header_modifier: HeaderModifier::default(),
                                 request_headers_to_add: vec![],
                                 request_headers_to_remove: vec![],
                                 virtual_hosts: vec![VirtualHost {
-                                    name: CompactString::from("vh1"),
+                                    name: SmolStr::new_static("vh1"),
                                     domains: vec![],
                                     routes: vec![Route {
                                         name: "test_route".to_owned(),
@@ -325,7 +325,6 @@ mod config_dump_tests {
 
     #[tokio::test]
     async fn config_dump_clusters() {
-        use compact_str::CompactString;
         use orion_configuration::config::{
             cluster::{
                 Cluster, ClusterDiscoveryType, ClusterLoadAssignment, HealthStatus, HttpProtocolOptions, LbEndpoint,
@@ -333,10 +332,11 @@ mod config_dump_tests {
             },
             core::envoy_conversions::Address,
         };
+        use smol_str::SmolStr;
         use std::{num::NonZeroU32, time::Duration};
         let endpoint_addr = Address::Socket("127.0.0.1".to_owned(), 9000);
         let cluster = Cluster {
-            name: CompactString::from("cluster1"),
+            name: SmolStr::new_static("cluster1"),
             discovery_settings: ClusterDiscoveryType::Static(ClusterLoadAssignment {
                 endpoints: vec![LocalityLbEndpoints {
                     priority: 0,
@@ -378,7 +378,6 @@ mod config_dump_tests {
 
     #[tokio::test]
     async fn config_dump_endpoints() {
-        use compact_str::CompactString;
         use orion_configuration::config::{
             cluster::{
                 Cluster, ClusterDiscoveryType, ClusterLoadAssignment, HealthStatus, HttpProtocolOptions, LbEndpoint,
@@ -386,10 +385,11 @@ mod config_dump_tests {
             },
             core::envoy_conversions::Address,
         };
+        use smol_str::SmolStr;
         use std::{num::NonZeroU32, time::Duration};
         let endpoint_addr = Address::Socket("127.0.0.1".to_owned(), 9000);
         let cluster = Cluster {
-            name: CompactString::from("cluster1"),
+            name: SmolStr::new_static("cluster1"),
             discovery_settings: ClusterDiscoveryType::Static(ClusterLoadAssignment {
                 endpoints: vec![LocalityLbEndpoints {
                     priority: 0,
@@ -432,8 +432,8 @@ mod config_dump_tests {
 
     #[tokio::test]
     async fn config_dump_secrets() {
-        use compact_str::CompactString;
         use orion_configuration::config::secret::{Secret, TlsCertificate, Type, ValidationContext};
+        use smol_str::SmolStr;
         use std::fs;
         let mut secret_manager = orion_lib::SecretManager::new();
 
@@ -454,7 +454,7 @@ mod config_dump_tests {
         .unwrap();
 
         let tls_secret = Secret {
-            name: CompactString::from("beefcake_dublin"),
+            name: SmolStr::new_static("beefcake_dublin"),
             kind: Type::TlsCertificate(
                 TlsCertificate::try_from(
                     orion_data_plane_api::envoy_data_plane_api::envoy::extensions::transport_sockets::tls::v3::TlsCertificate {
@@ -481,7 +481,7 @@ mod config_dump_tests {
             ),
         };
         let validation_secret = Secret {
-            name: CompactString::from("beefcake_ca"),
+            name: SmolStr::new_static("beefcake_ca"),
             kind: Type::ValidationContext(
                 ValidationContext::try_from(
                     orion_data_plane_api::envoy_data_plane_api::envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext {

--- a/orion-proxy/src/proxy.rs
+++ b/orion-proxy/src/proxy.rs
@@ -21,7 +21,6 @@ use crate::{
     runtime::{self, RuntimeId},
     xds_configurator::XdsConfigurationHandler,
 };
-use compact_str::ToCompactString;
 use futures::future::join_all;
 use orion_configuration::config::{
     bootstrap::Node,
@@ -38,6 +37,7 @@ use orion_lib::{
 };
 use orion_metrics::{metrics::init_global_metrics, wait_for_metrics_setup, Metrics, VecMetrics};
 use parking_lot::RwLock;
+use smol_str::ToSmolStr;
 use std::{
     collections::HashMap,
     sync::Arc,
@@ -310,11 +310,7 @@ async fn spawn_services(info: ServiceInfo) -> Result<()> {
                 listeners.iter().map(|l| (l.name.clone(), l.get_access_log_configurations())).collect::<Vec<_>>();
 
             for (listener_name, access_log_configurations) in listener_configurations {
-                _ = update_configuration(
-                    Target::Listener(listener_name.to_compact_string()),
-                    access_log_configurations,
-                )
-                .await;
+                _ = update_configuration(Target::Listener(listener_name.to_smolstr()), access_log_configurations).await;
             }
 
             handles.join_all().await;

--- a/orion-proxy/src/xds_configurator.rs
+++ b/orion-proxy/src/xds_configurator.rs
@@ -16,8 +16,6 @@
 //
 
 use abort_on_drop::ChildTask;
-#[cfg(feature = "tracing")]
-use compact_str::ToCompactString;
 use futures::future::join_all;
 use orion_configuration::config::{bootstrap::Node, cluster::ClusterSpecifier, Listener};
 use orion_lib::{
@@ -36,6 +34,8 @@ use orion_xds::{
     },
 };
 use parking_lot::RwLock;
+#[cfg(feature = "tracing")]
+use smol_str::ToSmolStr;
 use std::{sync::Arc, time::Duration};
 use tokio::{
     select,
@@ -322,7 +322,7 @@ impl XdsConfigurationHandler {
 
     #[cfg(feature = "tracing")]
     fn tracer_listener_remove(&self, id: &str) {
-        orion_tracing::otel_remove_tracers_by_listeners(&[id.to_compact_string()])
+        orion_tracing::otel_remove_tracers_by_listeners(&[id.to_smolstr()])
             .unwrap_or_else(|err| warn!("Failed to remove tracer for listener {id}: {err}"));
     }
 

--- a/orion-tracing/Cargo.toml
+++ b/orion-tracing/Cargo.toml
@@ -16,7 +16,7 @@ bounded-integer.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 serde.workspace = true
-compact_str.workspace = true
+smol_str.workspace = true
 thiserror.workspace = true
 http.workspace = true
 
@@ -36,7 +36,6 @@ opentelemetry_sdk = "0.29.0"
 parking_lot = "0.12.3"
 thread-id = "5.0.0"
 arc-swap = "1.7.1"
-smol_str = "0.3.2"
 uuid = { version = "1.18.0", features = ["v4"] }
 rand = "0.9.2"
 arrayvec = "0.7.6"

--- a/orion-tracing/src/lib.rs
+++ b/orion-tracing/src/lib.rs
@@ -35,18 +35,18 @@ use {
 use std::{collections::HashMap, sync::Arc};
 
 use arc_swap::ArcSwap;
-use compact_str::CompactString;
 use opentelemetry::global::BoxedTracer;
 use orion_configuration::config::network_filters::tracing::{SupportedTracingProvider, TracingConfig, TracingKey};
 use parking_lot::Mutex;
+use smol_str::SmolStr;
 use std::result::Result as StdResult;
 use thiserror::Error;
 #[cfg(feature = "tracing")]
-use {compact_str::ToCompactString, orion_error::Result};
+use {orion_error::Result, smol_str::ToSmolStr};
 
 #[allow(dead_code)]
 struct OtelConfig {
-    service_name: CompactString,
+    service_name: SmolStr,
     target_uri: String,
 }
 
@@ -102,14 +102,14 @@ impl TryFrom<&TracingConfig> for OtelConfig {
 }
 
 #[cfg(feature = "tracing")]
-pub fn otel_remove_tracers_by_listeners(listeners: &[CompactString]) -> Result<()> {
+pub fn otel_remove_tracers_by_listeners(listeners: &[SmolStr]) -> Result<()> {
     if !listeners.is_empty() {
         info!("OTEL Tracers: removing listeners configuration...");
         let _lock = GLOBAL_TRACERS.write_lock.lock();
         let map_arc = GLOBAL_TRACERS.tracers.load_full();
         let mut cur_map = (*map_arc).clone();
         info!("Removing tracer for listeners: {listeners:?}");
-        cur_map.retain(|&TracingKey(name, _), _| !listeners.contains(&name.to_compact_string()));
+        cur_map.retain(|&TracingKey(name, _), _| !listeners.contains(&name.to_smolstr()));
         GLOBAL_TRACERS.tracers.store(Arc::new(cur_map));
         info!("OTEL Tracers: removal done.");
     }


### PR DESCRIPTION
### Rationale

Currently, Orion utilizes a variety of string types, each chosen for specific performance or ergonomic reasons:

*`String`*: Used for general-purpose, heap-allocated string data.
*`CompactStr`*: Mostly adopted for component names (e.g., listeners, clusters) due to its clone efficiency over the standard `String`.
*`SmolStr`*: Used in the access logger as it proved to be more performant than `CompactStr` and offers a more ergonomic API.
*`&'static str` (via a String Interner)*: Recently, we introduced a string interner to represent component names as `&'static str`. This was a requirement for using them as long-lived tags in our OpenTelemetry integration (note: component's names have not been replaced but rather paired with their static str versions).

To make our string handling more consistent and streamlined, and to reduce the cognitive load of dealing with a large number of string-handling libraries, this pull request replaces compact_str with the more modern and efficient smol_str.

**Advantages** of smol_str over compact_str:

1. It is slightly more efficient when cloning a short string. It is much more efficient when cloning a string > 23 characters long.
2. Clone never involves dynamic memory allocation.
3. Construction is more efficient in some circumstances.
4. The interface is more nice.
6. Higher quality. Used as the core library in rust-analyzer.
