### PR TITLE
Optional XDS service, bug fixed.

### DIFF
--- a/orion-proxy/src/lib.rs
+++ b/orion-proxy/src/lib.rs
@@ -40,7 +40,8 @@ pub fn run() -> Result<()> {
         tracing::warn!("CAP_NET_RAW is NOT available, SO_BINDTODEVICE will not work");
     }
 
-    proxy::run_orion(bootstrap, access_logging)
+    proxy::run_orion(bootstrap, access_logging);
+    Ok(())
 }
 
 mod proxy_tracing {

--- a/orion-proxy/src/xds_configurator.rs
+++ b/orion-proxy/src/xds_configurator.rs
@@ -111,20 +111,7 @@ impl XdsConfigurationHandler {
         }
     }
 
-    pub async fn xds_run(
-        mut self,
-        node: Node,
-        initial_clusters: Vec<PartialClusterType>,
-        ads_cluster_names: Vec<String>,
-    ) -> Result<Self> {
-        select! {
-            _ = tokio::signal::ctrl_c() => info!("CTRL+C catch (service runtime)!"),
-            result = self.xds_run_loop(node, initial_clusters, ads_cluster_names) => result?,
-        }
-        Ok(self)
-    }
-
-    async fn xds_run_loop(
+    pub async fn run_loop(
         &mut self,
         node: Node,
         initial_clusters: Vec<PartialClusterType>,
@@ -173,7 +160,6 @@ impl XdsConfigurationHandler {
         }
 
         self.health_manager.stop_all().await;
-
         Ok(())
     }
 


### PR DESCRIPTION
This bugfix prevents the runtime services from terminating when no xDS clusters are configured and none of the services—such as access logs, metrics, tracing, or the administration interface—are enabled.

This fixes https://github.com/kmesh-net/orion/issues/81