### PR TITLE
Fix : Generate *-new.yaml files to temp directory instead of orion-proxy/conf/

### DIFF
--- a/orion-configuration/src/config.rs
+++ b/orion-configuration/src/config.rs
@@ -191,15 +191,16 @@ mod envoy_conversions {
                     let serialized = serde_yaml::to_string(&new_conf)?;
                     tracing::info!("\n{serialized}\n");
                     if !path.ends_with("new.yaml") {
-                        let new_path = format!(
-                            "../orion-proxy/conf/{}-new.yaml",
+                        let temp_dir = std::env::temp_dir();
+                        let new_path = temp_dir.join(format!(
+                            "{}-new.yaml",
                             path.file_name()
-                                .unwrap()
+                                .expect("path should have a file name")
                                 .to_str()
-                                .unwrap()
+                                .expect("file name should be valid UTF-8")
                                 .trim_end_matches(".yaml")
                                 .replace("envoy-", "orion-")
-                        );
+                        ));
                         std::fs::write(new_path, serialized.as_bytes())?;
                     }
                     let deserialized: Config = serde_yaml::from_str(&serialized)?;


### PR DESCRIPTION
- Changed the roundtrip_configs test to write *-new.yaml files to std::env::temp_dir()
- This prevents test artifacts from being accidentally committed to the repository
- Files are now written to /tmp/ instead of orion-proxy/conf/

Fixes : #70