### PR TITLE
Add CI job to check copyright headers in Rust source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,17 @@ jobs:
       
       - name: Run clippy (fail on warnings)
         run: cargo clippy --all-targets --all-features 
+      
+      - name: Check copyright headers
+        run: |
+          #!/bin/bash
+          set -e
+          find . -name "*.rs" -type f -not -path "./target/*" -not -path "./envoy-data-plane-api/*" | while read -r file; do
+            if ! head -1 "$file" | grep -q "Copyright"; then
+              echo "Missing copyright header in $file"
+              exit 1
+            fi
+          done 
 
   # Build and test that share artifacts
   build-and-test:


### PR DESCRIPTION
fixes  #95 