### PR TITLE
feat: allow multiple versions of the same listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,6 +1897,9 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "nohash"
@@ -2234,6 +2237,7 @@ dependencies = [
  "hyper-util",
  "ipnet",
  "lru_time_cache",
+ "multimap",
  "once_cell",
  "opentelemetry",
  "orion-configuration",

--- a/orion-lib/Cargo.toml
+++ b/orion-lib/Cargo.toml
@@ -27,6 +27,7 @@ hyper = { version = "1", features = ["full"] }
 hyper-rustls = { version = "0.27.1", features = ["default", "http2"] }
 ipnet = "2.9"
 lru_time_cache = "0.11.11"
+multimap = "0.10.0"
 once_cell = { version = "1.19" }
 opentelemetry = "0.29.0"
 hyper-util.workspace = true


### PR DESCRIPTION
- Change storage from BTreeMap to HashMap<String, Vec<ListenerInfo>>
- Add version tracking to prevent breaking existing connections
- Update start_listener to create new versions instead of stopping existing ones
- Modify stop_listener to handle multiple versions
- Update tests to verify multiple version functionality

fixes #98 