### PR TITLE
Add policy IDs to RBAC internal structures.

### DIFF
--- a/orion-configuration/src/config/network_filters/http_connection_manager/http_filters/http_rbac.rs
+++ b/orion-configuration/src/config/network_filters/http_connection_manager/http_filters/http_rbac.rs
@@ -86,7 +86,10 @@ impl HttpRbac {
             Action::Deny => enforced_policy.is_none(),
         };
 
-        debug!("HttpRbac: rule is enforced by {enforced_policy:?} with action: {:?} -> permitted {permitted}", self.action);
+        debug!(
+            "HttpRbac: rule is enforced by {enforced_policy:?} with action: {:?} -> permitted {permitted}",
+            self.action
+        );
         (permitted, enforced_policy)
     }
 }
@@ -118,7 +121,8 @@ mod rbac_tests {
         let permission = Permission::Any;
         let principal = Principal::Any;
         let policy = Policy { permissions: vec![permission], principals: vec![principal] };
-        let rbac_rule = HttpRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
+        let rbac_rule =
+            HttpRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
         let (permitted, rule) = rbac_rule.is_permitted(&create_host_request("blah.com"));
         assert!(permitted);
         assert_eq!(rule, Some("my-id".into()));
@@ -129,7 +133,8 @@ mod rbac_tests {
         let permission = Permission::Header(create_host_matcher(host));
         let principal = Principal::Any;
         let policy = Policy { permissions: vec![permission], principals: vec![principal] };
-        let rbac_rule = HttpRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
+        let rbac_rule =
+            HttpRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
         let (permitted, rule) = rbac_rule.is_permitted(&create_host_request(host));
         assert!(permitted);
         assert_eq!(rule, Some("my-id".into()));
@@ -142,7 +147,8 @@ mod rbac_tests {
         let permission2 = Permission::Any;
         let principal = Principal::Any;
         let policy = Policy { permissions: vec![permission1, permission2], principals: vec![principal] };
-        let rbac_rule = HttpRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
+        let rbac_rule =
+            HttpRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
         let (permitted, rule) = rbac_rule.is_permitted(&create_host_request(host));
         assert!(permitted);
         assert_eq!(rule, Some("my-id".into()));
@@ -154,7 +160,8 @@ mod rbac_tests {
         let permission = Permission::Header(create_host_matcher(host));
         let principal = Principal::Header(create_host_matcher(host));
         let policy = Policy { permissions: vec![permission], principals: vec![principal] };
-        let rbac_rule = HttpRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
+        let rbac_rule =
+            HttpRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
         let (permitted, rule) = rbac_rule.is_permitted(&create_host_request(host));
         assert!(permitted);
         assert_eq!(rule, Some("my-id".into()));
@@ -166,7 +173,8 @@ mod rbac_tests {
         let permission = Permission::Any;
         let principal = Principal::Any;
         let policy = Policy { permissions: vec![permission], principals: vec![principal] };
-        let rbac_rule = HttpRbac { action: Action::Deny, policies: vec![("my-id".into(), policy)].into_iter().collect() };
+        let rbac_rule =
+            HttpRbac { action: Action::Deny, policies: vec![("my-id".into(), policy)].into_iter().collect() };
         let (permitted, rule) = rbac_rule.is_permitted(&create_host_request(host));
         assert!(!permitted);
         assert_eq!(rule, Some("my-id".into()));
@@ -178,7 +186,8 @@ mod rbac_tests {
         let permission = Permission::Header(create_host_matcher(host));
         let principal = Principal::Any;
         let policy = Policy { permissions: vec![permission], principals: vec![principal] };
-        let rbac_rule = HttpRbac { action: Action::Deny, policies: vec![("my-id".into(), policy)].into_iter().collect() };
+        let rbac_rule =
+            HttpRbac { action: Action::Deny, policies: vec![("my-id".into(), policy)].into_iter().collect() };
         let (permitted, rule) = rbac_rule.is_permitted(&create_host_request(host));
         assert!(!permitted);
         assert_eq!(rule, Some("my-id".into()));
@@ -190,7 +199,8 @@ mod rbac_tests {
         let permission = Permission::Header(create_host_matcher(host));
         let principal = Principal::Header(create_host_matcher(host));
         let policy = Policy { permissions: vec![permission], principals: vec![principal] };
-        let rbac_rule = HttpRbac { action: Action::Deny, policies: vec![("my-id".into(), policy)].into_iter().collect() };
+        let rbac_rule =
+            HttpRbac { action: Action::Deny, policies: vec![("my-id".into(), policy)].into_iter().collect() };
         let (permitted, rule) = rbac_rule.is_permitted(&create_host_request(host));
         assert!(!permitted);
         assert_eq!(rule, Some("my-id".into()));

--- a/orion-configuration/src/config/network_filters/network_rbac.rs
+++ b/orion-configuration/src/config/network_filters/network_rbac.rs
@@ -112,7 +112,10 @@ impl NetworkRbac {
             Action::Deny => enforced_policy.is_none(),
         };
 
-        debug!("NetworkRbac: rule is enforced by {enforced_policy:?} with action: {:?} -> permitted {permitted}", self.action);
+        debug!(
+            "NetworkRbac: rule is enforced by {enforced_policy:?} with action: {:?} -> permitted {permitted}",
+            self.action
+        );
         (permitted, enforced_policy)
     }
 }
@@ -141,8 +144,10 @@ mod tests {
         let permission = Permission::Any;
         let principal = Principal::Any;
         let policy = Policy { permissions: vec![permission], principals: vec![principal] };
-        let rbac_rule = NetworkRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
-        let (permitted, rule) = rbac_rule.is_permitted(&create_network_context("127.0.0.1", 8000, "127.0.0.1", 9000, None));
+        let rbac_rule =
+            NetworkRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
+        let (permitted, rule) =
+            rbac_rule.is_permitted(&create_network_context("127.0.0.1", 8000, "127.0.0.1", 9000, None));
         assert!(permitted);
         assert_eq!(rule, Some("my-id".into()));
     }
@@ -151,8 +156,10 @@ mod tests {
         let permission = Permission::DestinationIp("127.0.0.0/24".parse().unwrap());
         let principal = Principal::Any;
         let policy = Policy { permissions: vec![permission], principals: vec![principal] };
-        let rbac_rule = NetworkRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
-        let (permitted, rule) = rbac_rule.is_permitted(&create_network_context("127.0.0.1", 8000, "127.0.0.1", 9000, None));
+        let rbac_rule =
+            NetworkRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
+        let (permitted, rule) =
+            rbac_rule.is_permitted(&create_network_context("127.0.0.1", 8000, "127.0.0.1", 9000, None));
         assert!(permitted);
         assert_eq!(rule, Some("my-id".into()));
     }
@@ -163,8 +170,10 @@ mod tests {
         let permission1 = Permission::Any;
         let principal = Principal::Any;
         let policy = Policy { permissions: vec![permission1, permission2], principals: vec![principal] };
-        let rbac_rule = NetworkRbac { action: Action::Allow, policies: vec![("my-id".into(),policy)].into_iter().collect() };
-        let (permitted, rule) =  rbac_rule.is_permitted(&create_network_context("127.0.0.1", 8000, "127.0.0.1", 9000, None));
+        let rbac_rule =
+            NetworkRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
+        let (permitted, rule) =
+            rbac_rule.is_permitted(&create_network_context("127.0.0.1", 8000, "127.0.0.1", 9000, None));
         assert!(permitted);
         assert_eq!(rule, Some("my-id".into()));
     }
@@ -175,8 +184,10 @@ mod tests {
         let permission1 = Permission::Any;
         let principal = Principal::Any;
         let policy = Policy { permissions: vec![permission1, permission2], principals: vec![principal] };
-        let rbac_rule = NetworkRbac { action: Action::Allow, policies: vec![("my-id".into(),policy)].into_iter().collect() };
-        let (permitted, rule) = rbac_rule.is_permitted(&create_network_context("127.0.0.1", 8000, "127.0.0.1", 9000, None));
+        let rbac_rule =
+            NetworkRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
+        let (permitted, rule) =
+            rbac_rule.is_permitted(&create_network_context("127.0.0.1", 8000, "127.0.0.1", 9000, None));
         assert!(permitted);
         assert_eq!(rule, Some("my-id".into()));
     }
@@ -186,8 +197,10 @@ mod tests {
         let permission = Permission::DestinationIp("127.0.0.0/24".parse().unwrap());
         let principal = Principal::DownstreamRemoteIp("127.0.0.0/24".parse().unwrap());
         let policy = Policy { permissions: vec![permission], principals: vec![principal] };
-        let rbac_rule = NetworkRbac { action: Action::Allow, policies: vec![("my-id".into(),policy)].into_iter().collect() };
-        let (permitted, rule) = rbac_rule.is_permitted(&create_network_context("127.0.0.1", 8000, "127.0.0.1", 9000, None));
+        let rbac_rule =
+            NetworkRbac { action: Action::Allow, policies: vec![("my-id".into(), policy)].into_iter().collect() };
+        let (permitted, rule) =
+            rbac_rule.is_permitted(&create_network_context("127.0.0.1", 8000, "127.0.0.1", 9000, None));
         assert!(permitted);
         assert_eq!(rule, Some("my-id".into()));
     }

--- a/orion-error/src/lib.rs
+++ b/orion-error/src/lib.rs
@@ -227,7 +227,7 @@ impl Context for Error {
     }
 }
 
-impl AsRef<(dyn ErrorTrait + Send + Sync + 'static)> for Error {
+impl AsRef<dyn ErrorTrait + Send + Sync + 'static> for Error {
     fn as_ref(&self) -> &(dyn ErrorTrait + Send + Sync + 'static) {
         &self.0
     }

--- a/orion-lib/src/event_error.rs
+++ b/orion-lib/src/event_error.rs
@@ -17,7 +17,9 @@
 
 use http::Response;
 use orion_format::types::ResponseFlags as FmtResponseFlags;
+use orion_interner::StringInterner;
 use std::error::Error as ErrorTrait;
+use compact_str::CompactString;
 use std::io;
 use tokio::time::error::Elapsed;
 
@@ -54,14 +56,14 @@ pub enum EventKind {
     NoHealthyUpstream,
     RouteNotFound,
     UpgradeFailed,
-    RbacAccessDenied,
+    RbacAccessDenied(CompactString),
     RateLimited,
     ViaUpstream,
 }
 
 impl EventKind {
     pub fn code_details(&self) -> Option<ResponseCodeDetails> {
-        match self {
+         match self {
             EventKind::Error(err) => match err {
                 EventError::IoError(err) => Some(ResponseCodeDetails::from(err)),
                 EventError::ConnectTimeout(_) => Some(ResponseCodeDetails("connect_timeout")),
@@ -79,7 +81,7 @@ impl EventKind {
             EventKind::NoHealthyUpstream => Some(ResponseCodeDetails("no_healthy_upstream")),
             EventKind::RouteNotFound => Some(ResponseCodeDetails("route_not_found")),
             EventKind::UpgradeFailed => Some(ResponseCodeDetails("upgrade_failed")),
-            EventKind::RbacAccessDenied => Some(ResponseCodeDetails("rbac_access_denied")),
+            EventKind::RbacAccessDenied(id) => Some(ResponseCodeDetails(format!("rbac_access_denied[{id}]").to_static_str())),
             EventKind::RateLimited => Some(ResponseCodeDetails("rate_limited")),
             EventKind::ViaUpstream => Some(ResponseCodeDetails("via_upstream")),
         }
@@ -93,7 +95,7 @@ impl EventKind {
                 EventError::RouteTimeout => Some(ConnectionTerminationDetails("route timeout was reached")),
                 _ => None,
             },
-            EventKind::RbacAccessDenied => Some(ConnectionTerminationDetails("rbac_access_denied_matched_policy")),
+            EventKind::RbacAccessDenied(id) => Some(ConnectionTerminationDetails(format!("rbac_access_denied_matched_policy[{id}]").to_static_str())),
             _ => None,
         }
     }

--- a/orion-lib/src/event_error.rs
+++ b/orion-lib/src/event_error.rs
@@ -15,11 +15,11 @@
 //
 //
 
+use compact_str::CompactString;
 use http::Response;
 use orion_format::types::ResponseFlags as FmtResponseFlags;
 use orion_interner::StringInterner;
 use std::error::Error as ErrorTrait;
-use compact_str::CompactString;
 use std::io;
 use tokio::time::error::Elapsed;
 
@@ -63,7 +63,7 @@ pub enum EventKind {
 
 impl EventKind {
     pub fn code_details(&self) -> Option<ResponseCodeDetails> {
-         match self {
+        match self {
             EventKind::Error(err) => match err {
                 EventError::IoError(err) => Some(ResponseCodeDetails::from(err)),
                 EventError::ConnectTimeout(_) => Some(ResponseCodeDetails("connect_timeout")),
@@ -81,7 +81,9 @@ impl EventKind {
             EventKind::NoHealthyUpstream => Some(ResponseCodeDetails("no_healthy_upstream")),
             EventKind::RouteNotFound => Some(ResponseCodeDetails("route_not_found")),
             EventKind::UpgradeFailed => Some(ResponseCodeDetails("upgrade_failed")),
-            EventKind::RbacAccessDenied(id) => Some(ResponseCodeDetails(format!("rbac_access_denied[{id}]").to_static_str())),
+            EventKind::RbacAccessDenied(id) => {
+                Some(ResponseCodeDetails(format!("rbac_access_denied[{id}]").to_static_str()))
+            },
             EventKind::RateLimited => Some(ResponseCodeDetails("rate_limited")),
             EventKind::ViaUpstream => Some(ResponseCodeDetails("via_upstream")),
         }
@@ -95,7 +97,9 @@ impl EventKind {
                 EventError::RouteTimeout => Some(ConnectionTerminationDetails("route timeout was reached")),
                 _ => None,
             },
-            EventKind::RbacAccessDenied(id) => Some(ConnectionTerminationDetails(format!("rbac_access_denied_matched_policy[{id}]").to_static_str())),
+            EventKind::RbacAccessDenied(id) => {
+                Some(ConnectionTerminationDetails(format!("rbac_access_denied_matched_policy[{id}]").to_static_str()))
+            },
             _ => None,
         }
     }

--- a/orion-lib/src/listeners/filterchain.rs
+++ b/orion-lib/src/listeners/filterchain.rs
@@ -161,7 +161,8 @@ impl FilterchainType {
         let network_context =
             NetworkContext::new(downstream_metadata.local_address(), downstream_metadata.peer_address(), server_name);
         for rbac in rbac_filters {
-            if !rbac.is_permitted(network_context) {
+            let (permitted, _) = rbac.is_permitted(&network_context);
+            if !permitted {
                 return None;
             }
         }

--- a/orion-lib/src/listeners/http_connection_manager.rs
+++ b/orion-lib/src/listeners/http_connection_manager.rs
@@ -1159,8 +1159,11 @@ fn apply_authorization_rules<B>(rbac: &HttpRbac, req: &Request<B>) -> FilterDeci
         FilterDecision::Continue
     } else {
         FilterDecision::DirectResponse(
-            SyntheticHttpResponse::forbidden(EventKind::RbacAccessDenied(enforced_policy.unwrap_or(CompactString::new("unknown"))), "RBAC: access denied")
-                .into_response(req.version()),
+            SyntheticHttpResponse::forbidden(
+                EventKind::RbacAccessDenied(enforced_policy.unwrap_or(CompactString::new("unknown"))),
+                "RBAC: access denied",
+            )
+            .into_response(req.version()),
         )
     }
 }

--- a/orion-lib/src/listeners/http_connection_manager.rs
+++ b/orion-lib/src/listeners/http_connection_manager.rs
@@ -1154,11 +1154,12 @@ fn eval_http_finish_context(
 
 fn apply_authorization_rules<B>(rbac: &HttpRbac, req: &Request<B>) -> FilterDecision {
     debug!("Applying authorization rules {rbac:?} {:?}", &req.headers());
-    if rbac.is_permitted(req) {
+    let (permitted, enforced_policy) = rbac.is_permitted(req);
+    if permitted {
         FilterDecision::Continue
     } else {
         FilterDecision::DirectResponse(
-            SyntheticHttpResponse::forbidden(EventKind::RbacAccessDenied, "RBAC: access denied")
+            SyntheticHttpResponse::forbidden(EventKind::RbacAccessDenied(enforced_policy.unwrap_or(CompactString::new("unknown"))), "RBAC: access denied")
                 .into_response(req.version()),
         )
     }


### PR DESCRIPTION
This MR enable IDs in Rbac name (id). Particularly:

- Replace Vec with BTreeMap for policies in HttpRbac and NetworkRbac 
- Update is_permitted to return (bool, Option<CompactString>) with matched policy 
- Update tests and conversions to use policy IDs 
- Include policy ID in EventKind::RbacAccessDenied and response code details